### PR TITLE
added R html links

### DIFF
--- a/_includes/dc/schedule.html
+++ b/_includes/dc/schedule.html
@@ -25,13 +25,13 @@
     <table class="table table-striped">
       <tr> <td>8:30 - 9:00</td>  <td>Installation Help</td> </tr>
       <tr><td>9:00 - 9:15</td> <td>Day 2 intro </td></tr>
-      <tr><td>9:15 - 10:30</td> <td> <a href="https://uw-madison-datascience.github.io/R-health-lesson/"> Intro to R </a> </td></tr>
+      <tr><td>9:15 - 10:30</td> <td> <a href="https://github.com/UW-Madison-DataScience/R-health-lesson/blob/master/_site/02-starting-with-data.html"> Intro to R </a> </td></tr>
       <tr><td>10:30 - 10:45</td> <td>Break</td></tr>
-      <tr><td>10:45 - 12:00</td> <td> <a href="https://uw-madison-datascience.github.io/R-health-lesson/"> Data manipulation with dplyr </a> </td></tr>
+      <tr><td>10:45 - 12:00</td> <td> <a href="https://github.com/UW-Madison-DataScience/R-health-lesson/blob/master/_site/03-dplyr.html"> Data manipulation with dplyr </a> </td></tr>
       <tr><td>12:00 - 1:00</td> <td>Lunch Break</td></tr>
-      <tr><td>1:00 - 2:30</td> <td> <a href="https://uw-madison-datascience.github.io/R-health-lesson/"> Data Visualization with ggplot2 </a> </td></tr>
+      <tr><td>1:00 - 2:30</td> <td> <a href="https://github.com/UW-Madison-DataScience/R-health-lesson/blob/master/_site/04-visualization-ggplot2.html"> Data Visualization with ggplot2 </a> </td></tr>
       <tr><td>2:30 - 2:45</td> <td>Coffee</td></tr>
-      <tr><td>2:45 - 3:15</td> <td> <a href="https://uw-madison-datascience.github.io/R-health-lesson/"> Reproducible reports with R Markdown </a> </td></tr>
+      <tr><td>2:45 - 3:15</td> <td> <a href="https://github.com/UW-Madison-DataScience/R-health-lesson/blob/master/_site/06-reports-rmarkdown.html"> Reproducible reports with R Markdown </a> </td></tr>
       <tr><td>3:15 - 4:00</td> <td> <a href="https://github.com/UW-Madison-DataScience/R-health-lesson/blob/master/capstone.Rmd"> Capstone Project </a> </td></tr>
       <tr><td>4:00 - 4:15</td> <td>Wrap up and fill out the post-workshop survey (see above)</td></tr>
       <tr>


### PR DESCRIPTION
I only added html links to the R lessons (I'm not sure if I'm doing this right - but thought I would give it a whirl). I don't know about the OpenRefine/SQL lessons. I also still need to add the htmls for the capstone and capstone solution.